### PR TITLE
Migrate to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ described in TI's Application Note [CC3100/CC3200 Embedded Programming](http://w
 
 ## Installation
 
-This runs on Python 2.7 with recent [pySerial](https://github.com/pyserial/pyserial).
+This runs on Python >=3.6 with recent [pySerial](https://github.com/pyserial/pyserial).
 
 To install, if you have pip and want system-wide:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A small tool to write files in TI's CC3200 SimpleLink (TM) filesystem.
 
-Copyright (C) 2016 Allterco Robotics
+Copyright (C) 2016-2020 Allterco Robotics
 
 ![](https://img.shields.io/badge/license-GPL_2-green.svg "License")
 
@@ -54,7 +54,7 @@ then it's just like any other python package:
 ## Usage
 
 You need a serial port connected to the target's UART interface. For
-programming to work, SOP2 needs to be asserted (i.e. tied to GND) and a reset
+programming to work, SOP2 needs to be asserted (i.e. tied to VCC) and a reset
 has to be peformed to switch the chip in bootloader mode. `cc3200tool` can
 optionally use the RTS and DTR lines of the serial port controller to
 automatically perform these actions via the `--sop2` and `--reset` options.
@@ -88,3 +88,9 @@ of arguments. Some examples:
 
     # list file and filesystem statistics (occupied and free block sequences)
     cc3200tool -p /dev/ttyUSB2 list_filesystem
+
+    # Reads all files to a directory and creates subdirecty structure
+    cc3200tool -p /dev/ttyUSB2 read_all_files extract/
+
+    # Writes all files from a directory and its subdirectories (add --simulate to skip writing)
+    cc3200tool -p /dev/ttyUSB2 write_all_files extract/

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ of arguments. Some examples:
     # list file and filesystem statistics (occupied and free block sequences)
     cc3200tool -p /dev/ttyUSB2 list_filesystem
 
-    # Reads all files to a directory and creates subdirecty structure
+    # Reads all files to a directory and creates subdirectory structure
     cc3200tool -p /dev/ttyUSB2 read_all_files extract/
 
     # Writes all files from a directory and its subdirectories (add --simulate to skip writing)

--- a/cc3200tool/__init__.py
+++ b/cc3200tool/__init__.py
@@ -1,0 +1,1 @@
+from cc import *

--- a/cc3200tool/__init__.py
+++ b/cc3200tool/__init__.py
@@ -1,1 +1,1 @@
-from cc import *
+from .cc import *

--- a/cc3200tool/cc.py
+++ b/cc3200tool/cc.py
@@ -539,7 +539,7 @@ class CC3x00SffsInfo(object):
             fname = fat_header.fat_bytes[fo_abs:fo_abs + fname_len]
 
             entry = CC3x00SffsStatsFileEntry(i, start_block, size_blocks,
-                                             mirrored, flags, fname)
+                                             mirrored, flags, fname.decode('ascii'))
             self.files.append(entry)
 
             occupied_block_snippets.append((start_block, entry.total_blocks))

--- a/cc3200tool/cc.py
+++ b/cc3200tool/cc.py
@@ -841,7 +841,7 @@ class CC3200Connection(object):
         assert len(response) == 4
         status = 0
         for b in response:
-            status = (status << 8) + ord(b)
+            status = (status << 8) + b
         #log.info('FS programming request: %d, response %s: %d', len(chunk), hexify(response), status)
         return status
 

--- a/cc3200tool/cc.py
+++ b/cc3200tool/cc.py
@@ -1,6 +1,6 @@
 #
 # cc3200tool - work with TI's CC3200 SimpleLink (TM) filesystem.
-# Copyright (C) 2016 Allterco Robotics
+# Copyright (C) 2016-2020 Allterco Robotics
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -119,6 +119,63 @@ def pinarg(extra=None):
 def auto_int(x):
     return int(x, 0)
 
+class PathType(object):
+    def __init__(self, exists=True, type='file', dash_ok=True):
+        '''exists:
+                True: a path that does exist
+                False: a path that does not exist, in a valid parent directory
+                None: don't care
+           type: file, dir, symlink, None, or a function returning True for valid paths
+                None: don't care
+           dash_ok: whether to allow "-" as stdin/stdout'''
+
+        assert exists in (True, False, None)
+        assert type in ('file','dir','symlink',None) or hasattr(type,'__call__')
+
+        self._exists = exists
+        self._type = type
+        self._dash_ok = dash_ok
+
+    def __call__(self, string):
+        if string=='-':
+            # the special argument "-" means sys.std{in,out}
+            if self._type == 'dir':
+                raise err('standard input/output (-) not allowed as directory path')
+            elif self._type == 'symlink':
+                raise err('standard input/output (-) not allowed as symlink path')
+            elif not self._dash_ok:
+                raise err('standard input/output (-) not allowed')
+        else:
+            e = os.path.exists(string)
+            if self._exists==True:
+                if not e:
+                    raise err("path does not exist: '%s'" % string)
+
+                if self._type is None:
+                    pass
+                elif self._type=='file':
+                    if not os.path.isfile(string):
+                        raise err("path is not a file: '%s'" % string)
+                elif self._type=='symlink':
+                    if not os.path.symlink(string):
+                        raise err("path is not a symlink: '%s'" % string)
+                elif self._type=='dir':
+                    if not os.path.isdir(string):
+                        raise err("path is not a directory: '%s'" % string)
+                elif not self._type(string):
+                    raise err("path not valid: '%s'" % string)
+            else:
+                if self._exists==False and e:
+                    raise err("path exists: '%s'" % string)
+
+                p = os.path.dirname(os.path.normpath(string)) or '.'
+                if not os.path.isdir(p):
+                    raise err("parent path is not a directory: '%s'" % p)
+                elif not os.path.exists(p):
+                    raise err("parent directory does not exist: '%s'" % p)
+
+        return string
+
 
 # TODO: replace argparse.FileType('rb') with manual file handling
 parser = argparse.ArgumentParser(description='Serial flash utility for CC3200')
@@ -222,6 +279,23 @@ def load_file(fname):
         data = f.read()
         assert len(data) > 0
     return data
+
+parser_read_all_files = subparsers.add_parser(
+        "read_all_files",
+        help="Reads all files into a subfolder structure")
+parser_read_all_files.add_argument(
+        "local_dir", type=PathType(exists=True, type='dir'),
+        help="local path to store the files in")
+
+parser_write_all_files = subparsers.add_parser(
+        "write_all_files",
+        help="Writes all files from a subfolder structure")
+parser_write_all_files.add_argument(
+        "local_dir", type=PathType(exists=True, type='dir'),
+        help="local path to read the files from")
+parser_write_all_files.add_argument(
+        "--simulate", action="store_false",
+        help="List all files to be written and skip writing them")
 
 def dll_data(fname):
     return get_data('cc3200tool', os.path.join('dll', fname))
@@ -1212,6 +1286,35 @@ class CC3200Connection(object):
         if json_output:
             fat_info.print_sffs_info_json()
 
+    def read_all_files(self, local_dir):
+        fat_info = self.get_fat_info(inactive=False)
+        fat_info.print_sffs_info()
+        for f in fat_info.files:
+            ccname = f.fname
+            if ccname.startswith('/'):
+                ccname = ccname[1:]
+            target_file = os.path.join(local_dir, ccname)
+            if not os.path.exists(os.path.dirname(target_file)):
+                os.makedirs(name=os.path.dirname(target_file))
+
+            try:
+                self.read_file(f.fname, open(target_file, 'wb', -1))
+            except:
+                log.error("File %s could not be read" % (f.fname))
+
+    def write_all_files(self, local_dir, write=True):
+        for root, dirs, files in os.walk(local_dir):
+            for file in files:
+                filepath = os.path.join(root, file)
+                ccpath = filepath[len(local_dir):]
+                if not ccpath.startswith("/"):
+                    ccpath = "/" + ccpath
+
+                if write:
+                    self.write_file(open(filepath, 'rb', -1), ccpath)
+                else:
+                    log.info("Simulation: Would copy local file %s to cc3200 %s" % (filepath, ccpath))
+
 
 def split_argv(cmdline_args):
     """Manually split sys.argv into subcommand sections
@@ -1316,6 +1419,13 @@ def main():
 
         if command.cmd == "list_filesystem":
             cc.list_filesystem(command.json_output, command.inactive)
+
+        if command.cmd == "read_all_files":
+            cc.read_all_files(command.local_dir)
+
+        if command.cmd == "write_all_files":
+            cc.write_all_files(command.local_dir, command.simulate)
+            check_fat = True
 
 
     if check_fat:

--- a/cc3200tool/cc.py
+++ b/cc3200tool/cc.py
@@ -43,23 +43,23 @@ CC3200_BAUD = 921600
 # so separate timeout value is used
 ERASE_TIMEOUT = 120
 
-OPCODE_START_UPLOAD = "\x21"
-OPCODE_FINISH_UPLOAD = "\x22"
-OPCODE_GET_LAST_STATUS = "\x23"
-OPCODE_FILE_CHUNK = "\x24"
-OPCODE_GET_STORAGE_LIST = "\x27"
-OPCODE_FORMAT_FLASH = "\x28"
-OPCODE_GET_FILE_INFO = "\x2A"
-OPCODE_READ_FILE_CHUNK = "\x2B"
-OPCODE_RAW_STORAGE_READ = "\x2C"
-OPCODE_RAW_STORAGE_WRITE = "\x2D"
-OPCODE_ERASE_FILE = "\x2E"
-OPCODE_GET_VERSION_INFO = "\x2F"
-OPCODE_RAW_STORAGE_ERASE = "\x30"
-OPCODE_GET_STORAGE_INFO = "\x31"
-OPCODE_EXEC_FROM_RAM = "\x32"
-OPCODE_SWITCH_2_APPS = "\x33"
-OPCODE_FS_PROGRAMMING = "\x34"
+OPCODE_START_UPLOAD = b'\x21'
+OPCODE_FINISH_UPLOAD = b'\x22'
+OPCODE_GET_LAST_STATUS = b'\x23'
+OPCODE_FILE_CHUNK = b'\x24'
+OPCODE_GET_STORAGE_LIST = b'\x27'
+OPCODE_FORMAT_FLASH = b'\x28'
+OPCODE_GET_FILE_INFO = b'\x2A'
+OPCODE_READ_FILE_CHUNK = b'\x2B'
+OPCODE_RAW_STORAGE_READ = b'\x2C'
+OPCODE_RAW_STORAGE_WRITE = b'\x2D'
+OPCODE_ERASE_FILE = b'\x2E'
+OPCODE_GET_VERSION_INFO = b'\x2F'
+OPCODE_RAW_STORAGE_ERASE = b'\x30'
+OPCODE_GET_STORAGE_INFO = b'\x31'
+OPCODE_EXEC_FROM_RAM = b'\x32'
+OPCODE_SWITCH_2_APPS = b'\x33'
+OPCODE_FS_PROGRAMMING = b'\x34'
 
 STORAGE_ID_SRAM = 0x0
 STORAGE_ID_SFLASH = 0x2
@@ -93,7 +93,7 @@ SLFS_MODE_OPEN_WRITE_CREATE_IF_NOT_EXIST = 3
 
 
 def hexify(s):
-    return " ".join([hex(ord(x)) for x in s])
+    return " ".join([hex(x) for x in s])
 
 
 Pincfg = namedtuple('Pincfg', ['invert', 'pin'])
@@ -110,8 +110,7 @@ def pinarg(extra=None):
             invert = True
             apin = apin[1:]
         if apin not in choices:
-            raise argparse.ArgumentTypeError("{} not one of {}".format(
-                    apin, choices))
+            raise argparse.ArgumentTypeError(f"{apin} not one of {choices}")
         return Pincfg(invert, apin)
 
     return _parse
@@ -154,7 +153,7 @@ parser_find_device = subparsers.add_parser(
 parser_format_flash = subparsers.add_parser(
         "format_flash", help="Format the flash memory")
 parser_format_flash.add_argument(
-        "-s", "--size", choices=SLFS_SIZE_MAP.keys(), default="1M")
+        "-s", "--size", choices=list(SLFS_SIZE_MAP.keys()), default="1M")
 
 parser_erase_file = subparsers.add_parser(
         "erase_file", help="Erase a file from the SL filesystem")
@@ -198,7 +197,7 @@ parser_write_flash.add_argument(
 parser_read_flash = subparsers.add_parser(
         "read_flash", help="Read SFFS contents into the file")
 parser_read_flash.add_argument(
-        "dump_file", type=argparse.FileType('w+'),
+        "dump_file", type=argparse.FileType('w+b'),
         help="path to store the SFFS dump")
 parser_read_flash.add_argument(
         "--offset", type=auto_int, default=0,
@@ -219,8 +218,7 @@ parser_list_filesystem.add_argument(
         help="output inactive FAT copy")
 
 def load_file(fname):
-    data = []
-    with open(fname, 'r') as f:
+    with open(fname, 'rb') as f:
         data = f.read()
         assert len(data) > 0
     return data
@@ -277,11 +275,11 @@ class CC3x00VersionInfo(object):
 
     @classmethod
     def from_packet(cls, data):
-        bootloader = tuple(map(ord, data[0:4]))
-        nwp = tuple(map(ord, data[4:8]))
-        mac = tuple(map(ord, data[8:12]))
-        phy = tuple(map(ord, data[12:16]))
-        chip_type = tuple(map(ord, data[16:20]))
+        bootloader = tuple(data[0:4])
+        nwp = tuple(data[4:8])
+        mac = tuple(data[8:12])
+        phy = tuple(data[12:16])
+        chip_type = tuple(data[16:20])
         return cls(bootloader, nwp, mac, phy, chip_type)
 
     def __repr__(self):
@@ -338,7 +336,7 @@ class CC3x00Status(object):
 
     @classmethod
     def from_packet(cls, packet):
-        return cls(ord(packet[3]))
+        return cls(packet[3])
 
 
 class CC3x00FileInfo(object):
@@ -348,7 +346,7 @@ class CC3x00FileInfo(object):
 
     @classmethod
     def from_packet(cls, data):
-        exists = data[0] == '\x01'
+        exists = data[0] == 0x01
         size = struct.unpack(">I", data[4:8])[0]
         return cls(exists, size)
 
@@ -431,7 +429,7 @@ class CC3x00SffsInfo(object):
             # scan the complete FAT table (as it appears to be)
             meta = fat_header.fat_bytes[(i + 1) * 4:(i + 2) * 4]
 
-            if meta == "\xff\xff\xff\xff" or meta == struct.pack("BBBB", 0xff, i, 0xff, 0x7f):
+            if meta == b"\xff\xff\xff\xff" or meta == struct.pack("BBBB", 0xff, i, 0xff, 0x7f):
                 # empty entry in the middle of the FAT table
                 continue
 
@@ -522,7 +520,7 @@ class CC3x00SffsInfo(object):
                  self.block_count - self.used_blocks)
 
     def print_sffs_info_json(self):
-        print json.dumps(self, cls=CustomJsonEncoder)
+        print(json.dumps(self, cls=CustomJsonEncoder))
 
 
 class CustomJsonEncoder(json.JSONEncoder):
@@ -579,14 +577,14 @@ class CC3200Connection(object):
             print("Reset the device with SOP2 {}asserted and press Enter".format(
                 '' if sop2 else 'de'
             ))
-            raw_input()
+            input()
             return
-        
+
         # in_reset = True ^ self._reset.invert
         self._set_reset_pin(True)
         time.sleep(.1)
         self._set_reset_pin(False)
-        
+
     def _set_reset_pin(self, state):
         state = not state if self._reset.invert else state
         if self._reset.pin == 'dtr':
@@ -615,7 +613,7 @@ class CC3200Connection(object):
                 ack_bytes.append(b)
                 if len(ack_bytes) > 2:
                     ack_bytes.pop(0)
-                if ack_bytes == ['\x00', '\xCC']:
+                if ack_bytes == [b'\x00', b'\xCC']:
                     return True
 
     def _read_packet(self, timeout=None):
@@ -633,11 +631,9 @@ class CC3200Connection(object):
         if (len(data) != data_len):
             raise CC3200Error("did not get entire response")
 
-        ccsum = 0
-        for x in data:
-            ccsum += ord(x)
+        ccsum = sum(data)
         ccsum = ccsum & 0xff
-        if ccsum != ord(csum_byte):
+        if ccsum != csum_byte:
             raise CC3200Error("rx csum failed")
 
         self._send_ack()
@@ -645,9 +641,7 @@ class CC3200Connection(object):
 
     def _send_packet(self, data, timeout=None):
         assert len(data)
-        checksum = 0
-        for b in data:
-            checksum += ord(b)
+        checksum = sum(data)
         len_blob = struct.pack(">H", len(data) + 2)
         csum = struct.pack("B", checksum & 0xff)
         if self.port.in_waiting or self.port.out_waiting:
@@ -656,16 +650,16 @@ class CC3200Connection(object):
         time.sleep(0.001)
         if not self._read_ack(timeout):
             raise CC3200Error(
-                    "No ack for packet opcode=0x{:02x}".format(ord(data[0])))
+                    f"No ack for packet opcode=0x{data[0]:02x}")
 
     def _send_ack(self):
-        self.port.write('\x00\xCC')
+        self.port.write(b'\x00\xCC')
 
     def _get_last_status(self):
         self._send_packet(OPCODE_GET_LAST_STATUS)
         status = self._read_packet()
         log.debug("get last status got %s", hexify(status))
-        return CC3x00Status(ord(status))
+        return CC3x00Status(status[0])
 
     def _do_break(self, timeout, break_cycles):
 
@@ -684,7 +678,7 @@ class CC3200Connection(object):
         else:
             self._set_reset_pin(False)
             return False
-        
+
     def _do_break_rpi(self, timeout, break_cycles):
         log.info("break_on")
         self.port.break_condition = True
@@ -716,8 +710,7 @@ class CC3200Connection(object):
         self._send_packet(OPCODE_GET_VERSION_INFO)
         version_data = self._read_packet()
         if len(version_data) != 28:
-            raise CC3200Error("Version info should be 28 bytes, got {}"
-                              .format(len(version_data)))
+            raise CC3200Error(f"Version info should be 28 bytes, got {len(version_data)}")
         return CC3x00VersionInfo.from_packet(version_data)
 
     def _get_storage_list(self):
@@ -727,7 +720,7 @@ class CC3200Connection(object):
             slist_byte = self.port.read(1)
             if len(slist_byte) != 1:
                 raise CC3200Error("Did not receive storage list byte")
-        return CC3x00StorageList(ord(slist_byte))
+        return CC3x00StorageList(slist_byte[0])
 
     def _get_storage_info(self, storage_id=STORAGE_ID_SRAM):
         log.info("Getting storage info...")
@@ -735,10 +728,9 @@ class CC3200Connection(object):
                           struct.pack(">I", storage_id))
         sinfo = self._read_packet()
         if len(sinfo) < 4:
-            raise CC3200Error("getting storage info got {} bytes"
-                              .format(len(sinfo)))
+            raise CC3200Error(f"getting storage info got {len(sinfo)} bytes")
         log.info("storage #%d info bytes: %s", storage_id, ", "
-                 .join([hex(ord(x)) for x in sinfo]))
+                 .join([hex(x) for x in sinfo]))
         return CC3x00StorageInfo.from_packet(sinfo)
 
     def erase_raw_storage(self, storage_id, start, count):
@@ -766,7 +758,7 @@ class CC3200Connection(object):
             raise CC3200Error('Raw Stroage Write failed, sent: %d', sent)
         log.info('write %d bytes to storage %d+%d success', len(data), storage_id, offset)
 
-    def _fs_programming(self, flags, chunk, key=''):
+    def _fs_programming(self, flags, chunk, key=b''):
         command = OPCODE_FS_PROGRAMMING + \
             struct.pack(">HHI", len(key), len(chunk), flags)
         #log.info('FS programming header: %s', hexify(command + key))
@@ -778,7 +770,7 @@ class CC3200Connection(object):
             status = (status << 8) + ord(b)
         #log.info('FS programming request: %d, response %s: %d', len(chunk), hexify(response), status)
         return status
-    
+
     def _erase_blocks(self, start, count, storage_id=STORAGE_ID_SRAM):
         command = OPCODE_RAW_STORAGE_ERASE + \
             struct.pack(">III", storage_id, start, count)
@@ -796,13 +788,6 @@ class CC3200Connection(object):
         if storage_id == STORAGE_ID_SRAM and not slist.sram:
             raise CC3200Error("no sram?!")
 
-        sinfo = self._get_storage_info(storage_id)
-        bs = sinfo.block_size
-        if bs > 0:
-            count = len(data) / bs
-            if count % bs:
-                count += 1
-
         chunk_size = 4080
         sent = 0
         data_len = len(data)
@@ -810,7 +795,7 @@ class CC3200Connection(object):
             chunk = data[sent:sent + chunk_size]
             self._send_chunk(offset + sent, chunk, storage_id)
             sent += len(chunk)
-            sys.stdout.write('\rProgress:%d%% ' % (sent * 100 / data_len))
+            sys.stdout.write('\rProgress:%d%% ' % (sent * 100 // data_len))
             sys.stdout.flush()
         sys.stdout.write(os.linesep)
 
@@ -856,12 +841,13 @@ class CC3200Connection(object):
 
         # XXX 4096 works faster, but 256 was sniffed from the uniflash
         chunk_size = 4096
-        rx_data = ''
+        rx_data = b''
         while size - len(rx_data) > 0:
             rx_data += self._read_chunk(offset + len(rx_data),
                                         min(chunk_size, size - len(rx_data)),
                                         storage_id)
             sys.stderr.write('.')
+            sys.stderr.flush()
         sys.stderr.write("\n")
         return rx_data
 
@@ -871,7 +857,7 @@ class CC3200Connection(object):
     def _get_file_info(self, filename):
         command = OPCODE_GET_FILE_INFO \
             + struct.pack(">I", len(filename)) \
-            + filename
+            + filename.encode()
         self._send_packet(command)
         finfo = self._read_packet()
         if len(finfo) < 5:
@@ -901,7 +887,7 @@ class CC3200Connection(object):
 
     def _open_file(self, filename, slfs_flags):
         command = OPCODE_START_UPLOAD + struct.pack(">II", slfs_flags, 0) + \
-            filename + '\x00\x00'
+            filename.encode() + b'\x00\x00'
         self._send_packet(command)
 
         token = self.port.read(4)
@@ -910,13 +896,13 @@ class CC3200Connection(object):
 
     def _close_file(self, signature=None):
         if signature is None:
-            signature = '\x46' * 256
+            signature = b'\x46' * 256
         if len(signature) != 256:
             raise CC3200Error("bad signature length")
         command = OPCODE_FINISH_UPLOAD
-        command += '\x00' * 63
+        command += b'\x00' * 63
         command += signature
-        command += '\x00'
+        command += b'\x00'
         self._send_packet(command)
         s = self._get_last_status()
         if not s.is_ok:
@@ -1021,7 +1007,7 @@ class CC3200Connection(object):
 
         log.info("Formatting flash with size=%s", size)
         command = OPCODE_FORMAT_FLASH \
-            + struct.pack(">IIIII", 2, size/4, 0, 0, 2)
+            + struct.pack(">IIIII", 2, size//4, 0, 0, 2)
 
         self._send_packet(command)
 
@@ -1038,11 +1024,11 @@ class CC3200Connection(object):
 
         log.info("Erasing file %s...", filename)
         command = OPCODE_ERASE_FILE + struct.pack(">I", 0) + \
-            filename + '\x00'
+            filename.encode() + b'\x00'
         self._send_packet(command)
         s = self._get_last_status()
         if not s.is_ok:
-            raise CC3200Error("Erasing file failed: 0x{:02x}}".format(s.value))
+            raise CC3200Error(f"Erasing file failed: 0x{s.value:02x}")
 
     def write_file(self, local_file, cc_filename, sign_file=None, size=0, commit_flag=False):
         # size must be known in advance, so read the whole thing
@@ -1078,7 +1064,7 @@ class CC3200Connection(object):
 
         timeout = self.port.timeout
         if (alloc_size_effective > 200000):
-            timeout = max(timeout, 5 * ((alloc_size_effective / 200000) + 1))  # empirical value is ~252925 bytes for 5 sec timeout
+            timeout = max(timeout, 5 * ((alloc_size_effective // 200000) + 1))  # empirical value is ~252925 bytes for 5 sec timeout
 
         log.info("Uploading file %s -> %s [%d, disk=%d]...",
                  local_file.name, cc_filename, alloc_size, alloc_size_effective)
@@ -1094,9 +1080,10 @@ class CC3200Connection(object):
             self._send_packet(command)
             res = self._get_last_status()
             if not res.is_ok:
-                raise CC3200Error("writing at pos {} failed".format(pos))
+                raise CC3200Error(f"writing at pos {pos} failed")
             pos += len(chunk)
             sys.stderr.write('.')
+            sys.stderr.flush()
 
         sys.stderr.write("\n")
         log.debug("Closing file ...")
@@ -1105,7 +1092,7 @@ class CC3200Connection(object):
     def read_file(self, cc_fname, local_file):
         finfo = self._get_file_info(cc_fname)
         if not finfo.exists:
-            raise CC3200Error("{} does not exist on target".format(cc_fname))
+            raise CC3200Error(f"{cc_fname} does not exist on target")
 
         log.info("Reading file %s -> %s", cc_fname, local_file.name)
 
@@ -1133,14 +1120,14 @@ class CC3200Connection(object):
             if erase:
                 count = int(math.ceil(data_len / float(SLFS_BLOCK_SIZE)))
                 self._erase_blocks(0, count, storage_id=STORAGE_ID_SFLASH)
-    
+
             self._raw_write(8, data[8:], storage_id=STORAGE_ID_SFLASH)
             self._raw_write(0, data[:8], storage_id=STORAGE_ID_SFLASH)
         else:
             log.info('flash image size: %d', data_len)
-    
+
             flags = 0
-            key_data = ''
+            key_data = b''
             key_size = 0
             chunk_size = 4096
             # TODO: add decryption
@@ -1156,14 +1143,14 @@ class CC3200Connection(object):
                 if (status != sent + chunk_size) and status != 0:
                     break
                 sent += len(chunk)
-                sys.stdout.write('\rProgress:%d%% ' % (sent * 100 / data_len))
+                sys.stdout.write('\rProgress:%d%% ' % (sent * 100 // data_len))
                 sys.stdout.flush()
             if data_len % chunk_size == 0:
-                status = self._fs_programming(flags, '', '')
+                status = self._fs_programming(flags, b'', b'')
                 log.info('FS programming status %d', status)
             if status:
                 log.info('FS programming aborted, bad response')
-            sys.stdout.write(os.linesep)   
+            sys.stdout.write(os.linesep)
 
     def read_flash(self, image_file, offset, size):
         data = self._raw_read(offset, size, storage_id=STORAGE_ID_SFLASH)
@@ -1288,7 +1275,7 @@ def main():
         cc.connect()
         log.info("connected to target")
     except (Exception, ) as e:
-        log.error("Could not connect to target: {}".format(e))
+        log.error(f"Could not connect to target: {e}")
         sys.exit(-3)
 
     log.info("Version: %s", cc.vinfo)

--- a/scripts/cc3200tool
+++ b/scripts/cc3200tool
@@ -1,7 +1,7 @@
 #!python
 #
 # cc3200tool - work with TI's CC3200 SimpleLink (TM) filesystem.
-# Copyright (C) 2016 Allterco Robotics
+# Copyright (C) 2016-2020 Allterco Robotics
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from distutils.core import setup
 
 setup(
     name="cc3200tool",
-    version="0.1.1",
-    description="A tool for CC32xx TI micro firmware update",
+    version="1.0.0",
+    description="A tool to upload files to TI CC32xx",
     author="Kiril Zyapkov",
     author_email="k.zyapkov@allterco.com",
     url="http://github.com/AlexLisnitski/cc3200tool",


### PR DESCRIPTION
A back-port of changes from mon/cc3200tool to support Python 3.
NOTE: this also drops python 2 compatility.

